### PR TITLE
docker: use image from docker hub to speed things up

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -84,7 +84,6 @@ services:
   joblib-hadoop-client:
     image: joblib/joblib-hadoop-client:latest
     container_name: joblib-hadoop-client
-    build: joblib-hadoop-client/.
     volumes:
       - ..:/shared # required for code coverage
     env_file:


### PR DESCRIPTION
Just a small PR to check if the actual build can also work from external PRs