### PR TITLE
ci: run test before examples to make sure coverage pass in conda env build code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,9 +50,6 @@ install:
     - cd docker && docker-compose ps && cd ..
 
 script:
-    # Run local unit tests first
-    # - make test
-
     # Run HDFS store backend, YARN parallel backend examples and pytest
     # are run from the joblib-hadoop-client docker container
     - make run-all

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,9 +50,8 @@ install:
     - cd docker && docker-compose ps && cd ..
 
 script:
-    # Run HDFS store backend, YARN parallel backend examples and pytest
-    # are run from the joblib-hadoop-client docker container
-    - make run-all
+    # Run pytest from the joblib-hadoop-client docker container
+    - make docker-test
 
 after_success:
     - echo ${PWD}

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ docker-pytest: install hdfs-clear test
 
 docker-examples: install examples
 
-docker-all: install examples hdfs-clear test
+docker-all: docker-pytest docker-examples
 
 # Pytest creates the Memory cache test results in /user/test in the hdfs
 # cluster, this target ensures we start from a fresh setup.


### PR DESCRIPTION
Just noticed that pytest was skipping some line in conda env creation because the env was previously built by one of the examples.

The fix just consists in running the test before. I'll came up with a smarter solution later (allow the possibility to configure the env name).